### PR TITLE
Add skipping  peer verification options for tls connections

### DIFF
--- a/lib/BasicIPP.php
+++ b/lib/BasicIPP.php
@@ -411,11 +411,11 @@ class BasicIPP
 
 		switch ($sides)
 		{
-			case 1:
+			case "1":
 				$sides = "one-sided";
 				break;
 
-			case 2:
+			case "2":
 				$sides = "two-sided-long-edge";
 				break;
 

--- a/lib/BasicIPP.php
+++ b/lib/BasicIPP.php
@@ -73,8 +73,8 @@ class BasicIPP
 	public $http_timeout = 30; // timeout at http connection (seconds) 0 => default => 30.
 	public $http_data_timeout = 30; // data reading timeout (milliseconds) 0 => default => 30.
 	public $ssl = false;
-    public $is_verify_peer = true;
-    public $is_verify_peer_name = true;
+	public $is_verify_peer = true;
+	public $is_verify_peer_name = true;
     public $debug_level = 3; // max 3: almost silent
 	public $alert_on_end_tag; // debugging purpose: echo "END tag OK" if (1 and  reads while end tag)
 	public $with_exceptions = 0; // compatibility mode for old scripts

--- a/lib/BasicIPP.php
+++ b/lib/BasicIPP.php
@@ -809,8 +809,8 @@ class BasicIPP
 		}
 		$http->port = $this->port;
 		$http->timeout = $this->http_timeout;
-        $http->is_verify_peer = $this->is_verify_peer;
-        $http->is_verify_peer_name = $this->is_verify_peer_name;
+		$http->is_verify_peer = $this->is_verify_peer;
+		$http->is_verify_peer_name = $this->is_verify_peer_name;
 		$http->data_timeout = $this->http_data_timeout;
 		$http->force_multipart_form_post = false;
 		$http->user = $this->username;

--- a/lib/BasicIPP.php
+++ b/lib/BasicIPP.php
@@ -73,7 +73,9 @@ class BasicIPP
 	public $http_timeout = 30; // timeout at http connection (seconds) 0 => default => 30.
 	public $http_data_timeout = 30; // data reading timeout (milliseconds) 0 => default => 30.
 	public $ssl = false;
-	public $debug_level = 3; // max 3: almost silent
+    public $is_verify_peer = true;
+    public $is_verify_peer_name = true;
+    public $debug_level = 3; // max 3: almost silent
 	public $alert_on_end_tag; // debugging purpose: echo "END tag OK" if (1 and  reads while end tag)
 	public $with_exceptions = 0; // compatibility mode for old scripts
 	public $handle_http_exceptions = 1;
@@ -807,6 +809,8 @@ class BasicIPP
 		}
 		$http->port = $this->port;
 		$http->timeout = $this->http_timeout;
+        $http->is_verify_peer = $this->is_verify_peer;
+        $http->is_verify_peer_name = $this->is_verify_peer_name;
 		$http->data_timeout = $this->http_data_timeout;
 		$http->force_multipart_form_post = false;
 		$http->user = $this->username;

--- a/lib/BasicIPP.php
+++ b/lib/BasicIPP.php
@@ -75,7 +75,7 @@ class BasicIPP
 	public $ssl = false;
 	public $is_verify_peer = true;
 	public $is_verify_peer_name = true;
-    public $debug_level = 3; // max 3: almost silent
+	public $debug_level = 3; // max 3: almost silent
 	public $alert_on_end_tag; // debugging purpose: echo "END tag OK" if (1 and  reads while end tag)
 	public $with_exceptions = 0; // compatibility mode for old scripts
 	public $handle_http_exceptions = 1;

--- a/lib/http_class.php
+++ b/lib/http_class.php
@@ -136,6 +136,8 @@ class http_class
 	public $data_timeout = 30; // time waiting for data, milliseconds
 	public $data_chunk_timeout = 1; // time waiting between data chunks, millisecond
 	public $force_multipart_form_post;
+    public $is_verify_peer = true;
+    public $is_verify_peer_name = true;
 	public $username;
 	public $password;
 	public $request_headers = array();
@@ -232,7 +234,17 @@ class http_class
 				}
 			}
 		}
-		$this->connection = @fsockopen($transport_type . $url, $port, $errno, $errstr, $this->timeout);
+        if ($transport_type == 'tls://'){
+            $context = stream_context_create([
+                'ssl' => [
+                    'verify_peer' => $this->is_verify_peer,
+                    'verify_peer_name' => $this->is_verify_peer_name
+                ]
+            ]);
+            $this->connection  = @stream_socket_client($transport_type . $url.':'.$port, $errno, $errstr, $this->timeout, STREAM_CLIENT_CONNECT, $context);
+        }else {
+            $this->connection = @fsockopen($transport_type . $url, $port, $errno, $errstr, $this->timeout);
+        }
 		$error =
 			sprintf(_('Unable to connect to "%s%s port %s": %s'), $transport_type,
 				$url, $port, $errstr);

--- a/lib/http_class.php
+++ b/lib/http_class.php
@@ -136,8 +136,8 @@ class http_class
 	public $data_timeout = 30; // time waiting for data, milliseconds
 	public $data_chunk_timeout = 1; // time waiting between data chunks, millisecond
 	public $force_multipart_form_post;
-    public $is_verify_peer = true;
-    public $is_verify_peer_name = true;
+	public $is_verify_peer = true;
+	public $is_verify_peer_name = true;
 	public $username;
 	public $password;
 	public $request_headers = array();

--- a/lib/http_class.php
+++ b/lib/http_class.php
@@ -234,17 +234,17 @@ class http_class
 				}
 			}
 		}
-        if ($transport_type == 'tls://'){
-            $context = stream_context_create([
-                'ssl' => [
-                    'verify_peer' => $this->is_verify_peer,
-                    'verify_peer_name' => $this->is_verify_peer_name
-                ]
-            ]);
-            $this->connection  = @stream_socket_client($transport_type . $url.':'.$port, $errno, $errstr, $this->timeout, STREAM_CLIENT_CONNECT, $context);
-        }else {
-            $this->connection = @fsockopen($transport_type . $url, $port, $errno, $errstr, $this->timeout);
-        }
+		if ($transport_type == 'tls://'){
+			$context = stream_context_create([
+				'ssl' => [
+					'verify_peer' => $this->is_verify_peer,
+					'verify_peer_name' => $this->is_verify_peer_name
+				]
+			]);
+			$this->connection  = @stream_socket_client($transport_type . $url.':'.$port, $errno, $errstr, $this->timeout, STREAM_CLIENT_CONNECT, $context);
+		}else {
+			$this->connection = @fsockopen($transport_type . $url, $port, $errno, $errstr, $this->timeout);
+		}
 		$error =
 			sprintf(_('Unable to connect to "%s%s port %s": %s'), $transport_type,
 				$url, $port, $errstr);


### PR DESCRIPTION
Add two boolean variables to http_class and BasicPP

$is_verify_peer (default true)
$is_verify_peer_name (default true)

Those changes enable to skip peer verification. Useful for self signed certificates.